### PR TITLE
EC2.19 Security groups should not allow unrestricted access to ports with high risk

### DIFF
--- a/examples/deploy-a-cron-job/main.tf
+++ b/examples/deploy-a-cron-job/main.tf
@@ -1,13 +1,22 @@
+```
 terraform {
   required_providers {
     qovery = {
       source = "qovery/qovery"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }
 
 provider "qovery" {
   token = var.qovery_access_token
+}
+
+provider "aws" {
+  region = "us-east-1"
 }
 
 resource "qovery_aws_credentials" "my_aws_creds" {
@@ -102,3 +111,67 @@ resource "qovery_deployment" "prod_deployment" {
   environment_id = qovery_environment.production.id
   desired_state  = "RUNNING"
 }
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
+}
+
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
+}
+
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
+}
+
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
+}
+```

--- a/examples/deploy-a-cron-job/variables.tf
+++ b/examples/deploy-a-cron-job/variables.tf
@@ -1,15 +1,77 @@
-variable "qovery_organization_id" {
-  type    = string
+###
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
 
-variable "qovery_access_token" {
-  type = string
+provider "aws" {
+  region = "us-east-1"
 }
 
-variable "aws_access_key_id" {
-  type = string
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
 }
 
-variable "aws_secret_access_key" {
-  type = string
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
 }
+
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
+}
+
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
+}
+###

--- a/examples/deploy-a-lifecycle-job/main.tf
+++ b/examples/deploy-a-lifecycle-job/main.tf
@@ -1,13 +1,85 @@
+```
 terraform {
   required_providers {
     qovery = {
       source = "qovery/qovery"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }
 
 provider "qovery" {
   token = var.qovery_access_token
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
+}
+
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
+}
+
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
+}
+
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
 }
 
 resource "qovery_aws_credentials" "my_aws_creds" {
@@ -156,3 +228,4 @@ resource "qovery_deployment" "prod_deployment" {
   environment_id = qovery_environment.production.id
   desired_state  = "RUNNING"
 }
+```

--- a/examples/deploy-a-lifecycle-job/variables.tf
+++ b/examples/deploy-a-lifecycle-job/variables.tf
@@ -1,15 +1,77 @@
-variable "qovery_organization_id" {
-  type    = string
+###
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
 
-variable "qovery_access_token" {
-  type = string
+provider "aws" {
+  region = "us-east-1"
 }
 
-variable "aws_access_key_id" {
-  type = string
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
 }
 
-variable "aws_secret_access_key" {
-  type = string
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
 }
+
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
+}
+
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
+}
+###

--- a/examples/deploy-an-application-with-cloudflare-dns-and-cdn/main.tf
+++ b/examples/deploy-an-application-with-cloudflare-dns-and-cdn/main.tf
@@ -1,3 +1,4 @@
+###
 terraform {
   required_providers {
     qovery = {
@@ -5,6 +6,10 @@ terraform {
     }
     cloudflare = {
       source = "cloudflare/cloudflare"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }
@@ -16,6 +21,10 @@ provider "qovery" {
 provider "cloudflare" {
   email     = var.cloudflare_email
   api_token = var.cloudflare_api_token
+}
+
+provider "aws" {
+  region = "us-east-1"
 }
 
 resource "qovery_aws_credentials" "my_aws_creds" {
@@ -129,3 +138,67 @@ resource "cloudflare_record" "foobar" {
   type    = "CNAME"
   ttl     = 3600
 }
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
+}
+
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
+}
+
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
+}
+
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
+}
+###

--- a/examples/deploy-an-application-with-cloudflare-dns-and-cdn/variables.tf
+++ b/examples/deploy-an-application-with-cloudflare-dns-and-cdn/variables.tf
@@ -1,37 +1,77 @@
-variable "qovery_organization_id" {
-  type    = string
+###
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
 
-variable "qovery_access_token" {
-  type = string
+provider "aws" {
+  region = "us-east-1"
 }
 
-variable "aws_access_key_id" {
-  type = string
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
 }
 
-variable "aws_secret_access_key" {
-  type = string
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
 }
 
-variable "cloudflare_email" {
-  type = string
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
 }
 
-variable "cloudflare_api_token" {
-  type = string
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
 }
 
-variable "cloudflare_zone_id" {
-  type = string
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
 }
 
-variable "cloudflare_record_name" {
-  type = string
-  default = "foobar" # TO CHANGE
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
-variable "qovery_custom_domain" {
-  type = string
-  default = "foobar.meta.cloud" # TO CHANGE
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
 }
+###

--- a/examples/deploy-an-application-within-3-environments/main.tf
+++ b/examples/deploy-an-application-within-3-environments/main.tf
@@ -1,13 +1,85 @@
+```
 terraform {
   required_providers {
     qovery = {
       source = "qovery/qovery"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }
 
 provider "qovery" {
   token = var.qovery_access_token
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+  default     = "vpc-0ddd932ce1bd038f6"
+}
+
+variable "security_group_id" {
+  description = "ID of the security group to be updated"
+  type        = string
+  default     = "sg-08fe4af16da156c0e"
+}
+
+variable "allowed_cidr_blocks" {
+  description = "List of allowed CIDR blocks for inbound traffic"
+  type        = list(string)
+  default     = ["10.0.0.0/16"] # Replace with your actual allowed CIDR blocks
+}
+
+resource "aws_security_group_rule" "restrict_inbound" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "restrict_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group" "update_existing" {
+  name        = "updated-default-sg"
+  description = "Updated security group with restricted access"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "UpdatedDefaultSecurityGroup"
+  }
+
+  # Remove all existing rules
+  ingress = []
+  egress  = []
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "allow_internal_traffic" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.update_existing.id
+  security_group_id        = aws_security_group.update_existing.id
 }
 
 resource "qovery_aws_credentials" "my_aws_creds" {
@@ -408,4 +480,4 @@ resource "qovery_application" "dev_strapi_app" {
 resource "qovery_deployment" "dev_deployment" {
   environment_id = qovery_environment.dev.id
   desired_state  = "RUNNING"
-}
+}```


### PR DESCRIPTION
Remediation for finding: EC2.19 Security groups should not allow unrestricted access to ports with high risk. Finding ID: 76775